### PR TITLE
windows ssh askpass quoting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1376,6 +1376,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 env = new EnvVars(env);
                 env.put("GIT_SSH", ssh.getAbsolutePath());
                 env.put("SSH_ASKPASS", pass.getAbsolutePath());
+
+                // supply a dummy value for DISPLAY if not already present
+                // or else ssh will not invoke SSH_ASKPASS
+                if (!env.containsKey("DISPLAY")) {
+                    env.put("DISPLAY", ":");
+                }
+
             }
 
             if ("http".equalsIgnoreCase(url.getScheme()) || "https".equalsIgnoreCase(url.getScheme())) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1518,7 +1518,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         PrintWriter w = null;
         try {
             w = new PrintWriter(ssh);
-            w.println("echo \"" + Secret.toString(sshUser.getPassphrase()) + "\"");
+            // avoid echoing command as part of the password
+            w.println("@echo off");
+            // no need for quotes on windows echo -- they will get echoed too
+            w.println("echo " + Secret.toString(sshUser.getPassphrase()));
             w.flush();
         } finally {
             if (w != null) {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1534,6 +1534,8 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     // f(x)
     // git.exe
     // "git.exe"
+    // "git.exe's"
+    // 'git.exe"s'
     // x"|date
     // x|date
     // ----- End of private key passphrases -----

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1561,16 +1561,16 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     // saint2Coors4kazoo56th4hying2wing
     // Barry Gordon<barry.gordon@gmail.com>
     // Mark&Earl
-    // 1<2
-    // 2>1
-    // :(
-    // :)
+    // 123<456
+    // 987>654
+    // :(frown
+    // :)smile
     // mark.earl.waite@gmail.com
-    // x^2
-    // a|b
+    // x^2+x**3
+    // a|b|c|d
     // Mark's
     // "quoted"
-    // f(x)
+    // f(abcx)
     // git.exe
     // "git.exe"
     // "git.exe's"

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1520,7 +1520,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     // double slash and single space)
     // ----- Start of private key passphrases -----
     // saint2Coors4kazoo56th4hying2wing
-    // <mark|earl^waite>@gmail.com
+    // Barry Gordon<barry.gordon@gmail.com>
     // Mark&Earl
     // 1<2
     // 2>1
@@ -1541,19 +1541,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     // ----- End of private key passphrases -----
     private boolean passphraseUsesWindowsSpecialCharacters(SSHUserPrivateKey sshUser) {
         final String passphrase = Secret.toString(sshUser.getPassphrase());
-        if (passphrase.contains("&")
-            || passphrase.contains("<")
-            || passphrase.contains(">")
-            || passphrase.contains("<")
+        if (   passphrase.contains(" ")
+            || passphrase.contains("&")
+            || passphrase.contains("'")
             || passphrase.contains("(")
             || passphrase.contains(")")
+            || passphrase.contains("<")
+            || passphrase.contains(">")
             || passphrase.contains("@")
-            || passphrase.contains("^")
-            || passphrase.contains("|")
-            || passphrase.contains("'")
             || passphrase.contains("\"")
             || passphrase.contains("\\")
-            || passphrase.contains(" ")
+            || passphrase.contains("^")
+            || passphrase.contains("|")
             ) {
             listener.getLogger().println("plaintext passphrase '" + passphrase + "' contains Windows command processor special character");
             return true;

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1520,8 +1520,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private File createWindowsSshAskpass(SSHUserPrivateKey sshUser, File passphrase) throws IOException {
-        File ssh = workspace.createTempFile("pass", ".bat");
-        listener.getLogger().println("Wrote bat to '" + ssh.getAbsolutePath() + "'");
+        File ssh = File.createTempFile("pass", ".bat");
         PrintWriter w = null;
         try {
             w = new PrintWriter(ssh, "UTF-8");
@@ -1539,8 +1538,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     private File createUnixSshAskpass(SSHUserPrivateKey sshUser, File passphrase) throws IOException {
-        File ssh = workspace.createTempFile("pass", ".sh");
-        listener.getLogger().println("Wrote sh script to '" + ssh.getAbsolutePath() + "'");
+        File ssh = File.createTempFile("pass", ".sh");
         PrintWriter w = null;
         try {
             w = new PrintWriter(ssh, "UTF-8");
@@ -1582,7 +1580,6 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     // ----- End of private key passphrases -----
     private File writePassphraseToFile(SSHUserPrivateKey sshUser) throws IOException {
         File passphraseFile = workspace.createTempFile("phrase", ".txt");
-        listener.getLogger().println("Wrote passphrase to '" + passphraseFile.getAbsolutePath() + "'");
         PrintWriter w = null;
         try {
             w = new PrintWriter(passphraseFile, "UTF-8");

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1540,6 +1540,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     private File createUnixSshAskpass(SSHUserPrivateKey sshUser, File passphrase) throws IOException {
         File ssh = File.createTempFile("pass", ".sh");
         PrintWriter w = null;
+        listener.getLogger().println(MessageFormat.format("Writing 'cat {0}' to '{1}'", passphrase.getAbsolutePath(), ssh));
         try {
             w = new PrintWriter(ssh, "UTF-8");
             // avoid echoing command as part of the password
@@ -1555,31 +1556,9 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         return ssh;
     }
 
-    // RSA private key passphrases to test (literal text follows the
-    // double slash and single space)
-    // ----- Start of private key passphrases -----
-    // saint2Coors4kazoo56th4hying2wing
-    // Barry Gordon<barry.gordon@gmail.com>
-    // Mark&Earl
-    // 123<456
-    // 987>654
-    // :(frown
-    // :)smile
-    // mark.earl.waite@gmail.com
-    // x^2+x**3
-    // a|b|c|d
-    // Mark's
-    // "quoted"
-    // f(abcx)
-    // git.exe
-    // "git.exe"
-    // "git.exe's"
-    // 'git.exe"s'
-    // x"|date
-    // x|date
-    // ----- End of private key passphrases -----
     private File writePassphraseToFile(SSHUserPrivateKey sshUser) throws IOException {
         File passphraseFile = workspace.createTempFile("phrase", ".txt");
+        listener.getLogger().println(MessageFormat.format("Writing passphrase '{0}' to '{1}'", sshUser.getPassphrase(), passphraseFile));
         PrintWriter w = null;
         try {
             w = new PrintWriter(passphraseFile, "UTF-8");

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -179,7 +179,7 @@ public class CredentialsTest {
         return cli.isAtLeastVersion(1, 7, 9, 0);
     }
 
-    @Parameterized.Parameters(name = "{2}-{1}-{0}")
+    @Parameterized.Parameters(name = "{2}-{1}-{0}-{5}")
     public static Collection gitRepoUrls() throws MalformedURLException, FileNotFoundException, IOException, InterruptedException, ParseException {
         List<Object[]> repos = new ArrayList<Object[]>();
         String[] implementations = isCredentialsSupported() ? new String[]{"git", "jgit"} : new String[]{"jgit"};


### PR DESCRIPTION
Considering using Linux `cat` and Windows `type` commands instead of using `echo` to send the ssh passphrase to the ssh command.
