### PR TITLE
Update to JGit 4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <jgit.version>4.4.1.201607150455-r</jgit.version>
+    <jgit.version>4.5.0.201609210915-r</jgit.version>
   </properties>
 
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/JGitAPIImpl.java
@@ -516,7 +516,6 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
 
             public org.jenkinsci.plugins.gitclient.FetchCommand prune() {
-                //throw new UnsupportedOperationException("JGit don't (yet) support pruning during fetch");
                 shouldPrune = true;
                 return this;
             }
@@ -567,10 +566,12 @@ public class JGitAPIImpl extends LegacyCompatibleGitAPIImpl {
 
                         for (ListIterator<Ref> it = refs.listIterator(); it.hasNext(); ) {
                             Ref branchRef = it.next();
-                            for (RefSpec rs : refSpecs) {
-                                if (rs.matchDestination(branchRef)) {
-                                    toDelete.add(branchRef.getName());
-                                    break;
+                            if (!branchRef.isSymbolic()) { // Don't delete HEAD and other symbolic refs
+                                for (RefSpec rs : refSpecs) {
+                                    if (rs.matchDestination(branchRef)) {
+                                        toDelete.add(branchRef.getName());
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1146,7 +1146,7 @@ public abstract class GitAPITestCase extends TestCase {
             assertTrue("CliGit should have thrown an exception", newArea.git instanceof JGitAPIImpl);
         } catch (GitException ge) {
             final String msg = ge.getMessage();
-            assertTrue("Wrong exception: " + msg, msg.contains("some local refs could not be updated"));
+            assertTrue("Wrong exception: " + msg, msg.contains("some local refs could not be updated") || msg.contains("error: cannot lock ref "));
         }
 
         /* Use git remote prune origin to remove obsolete branch named "parent" */


### PR DESCRIPTION
prune behavior has changed enough that one of the JGit API implementation tests now fails.  A preliminary change to adapt to the JGit API change is included, but needs more investigation.
