### PR TITLE
Adapt to CLI git limits on special characters in workspace path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <excludes>
-	      <!-- <exclude>CliGitAPIImplAuthTest</exclude> -->
-	      <!-- <exclude>CliGitAPIImplTest</exclude> -->
+              <!-- <exclude>CliGitAPIImplAuthTest</exclude> -->
+              <exclude>CliGitAPIImplTest</exclude>
               <exclude>CredentialsProviderImplTest</exclude>
               <!-- <exclude>CredentialsTest</exclude> -->
               <exclude>FilePermissionsTest</exclude>
@@ -187,7 +187,7 @@
               <exclude>IndexEntryTest</exclude>
               <exclude>InjectedTest</exclude>
               <exclude>JGitApacheAPIImplTest</exclude>
-              <exclude>JGitAPIImplTest</exclude>
+              <!-- <exclude>JGitAPIImplTest</exclude> -->
               <exclude>LegacyCompatibleGitAPIImplJGitTest</exclude>
               <exclude>LegacyCompatibleGitAPIImplTest</exclude>
               <exclude>LogHandlerTest</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,42 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <excludes>
+              <exclude>CliGitAPIImplAuthTest</exclude>
+              <exclude>CliGitAPIImplTest</exclude>
+              <exclude>CredentialsProviderImplTest</exclude>
+              <!-- <exclude>CredentialsTest</exclude> -->
+              <exclude>FilePermissionsTest</exclude>
+              <exclude>GitAPIBadInitTest</exclude>
+              <exclude>GitAPITestCase</exclude>
+              <exclude>GitClientTest</exclude>
+              <exclude>GitExceptionTest</exclude>
+              <exclude>GitLockFailedExceptionTest</exclude>
+              <exclude>GitObjectTest</exclude>
+              <exclude>GitTest</exclude>
+              <exclude>GitToolTest</exclude>
+              <exclude>GitURIRequirementsBuilderTest</exclude>
+              <exclude>IndexEntryTest</exclude>
+              <exclude>InjectedTest</exclude>
+              <exclude>JGitApacheAPIImplTest</exclude>
+              <exclude>JGitAPIImplTest</exclude>
+              <exclude>LegacyCompatibleGitAPIImplJGitTest</exclude>
+              <exclude>LegacyCompatibleGitAPIImplTest</exclude>
+              <exclude>LogHandlerTest</exclude>
+              <exclude>MergeCommandTest</exclude>
+              <exclude>NetrcTest</exclude>
+              <exclude>PreemptiveAuthHttpClientConnectionTest</exclude>
+              <exclude>PushSimpleTest</exclude>
+              <exclude>PushTest</exclude>
+              <exclude>RemotingTest</exclude>
+              <exclude>RevisionTest</exclude>
+              <exclude>SmartCredentialsProviderTest</exclude>
+              <!-- <exclude>SubmoduleTest</exclude> -->
+              <exclude>TagTest</exclude>
+              <exclude>WarnTempDirValueTest</exclude>
+            </excludes>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <excludes>
-              <exclude>CliGitAPIImplAuthTest</exclude>
-              <exclude>CliGitAPIImplTest</exclude>
+	      <!-- <exclude>CliGitAPIImplAuthTest</exclude> -->
+	      <!-- <exclude>CliGitAPIImplTest</exclude> -->
               <exclude>CredentialsProviderImplTest</exclude>
               <!-- <exclude>CredentialsTest</exclude> -->
               <exclude>FilePermissionsTest</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -170,8 +170,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <excludes>
-              <!-- <exclude>CliGitAPIImplAuthTest</exclude> -->
-              <exclude>CliGitAPIImplTest</exclude>
+	      <!-- <exclude>CliGitAPIImplAuthTest</exclude> -->
+	      <!-- <exclude>CliGitAPIImplTest</exclude> -->
               <exclude>CredentialsProviderImplTest</exclude>
               <!-- <exclude>CredentialsTest</exclude> -->
               <exclude>FilePermissionsTest</exclude>
@@ -187,7 +187,7 @@
               <exclude>IndexEntryTest</exclude>
               <exclude>InjectedTest</exclude>
               <exclude>JGitApacheAPIImplTest</exclude>
-              <!-- <exclude>JGitAPIImplTest</exclude> -->
+              <exclude>JGitAPIImplTest</exclude>
               <exclude>LegacyCompatibleGitAPIImplJGitTest</exclude>
               <exclude>LegacyCompatibleGitAPIImplTest</exclude>
               <exclude>LogHandlerTest</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -168,42 +168,6 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <excludes>
-	      <!-- <exclude>CliGitAPIImplAuthTest</exclude> -->
-	      <!-- <exclude>CliGitAPIImplTest</exclude> -->
-              <exclude>CredentialsProviderImplTest</exclude>
-              <!-- <exclude>CredentialsTest</exclude> -->
-              <exclude>FilePermissionsTest</exclude>
-              <exclude>GitAPIBadInitTest</exclude>
-              <exclude>GitAPITestCase</exclude>
-              <exclude>GitClientTest</exclude>
-              <exclude>GitExceptionTest</exclude>
-              <exclude>GitLockFailedExceptionTest</exclude>
-              <exclude>GitObjectTest</exclude>
-              <exclude>GitTest</exclude>
-              <exclude>GitToolTest</exclude>
-              <exclude>GitURIRequirementsBuilderTest</exclude>
-              <exclude>IndexEntryTest</exclude>
-              <exclude>InjectedTest</exclude>
-              <exclude>JGitApacheAPIImplTest</exclude>
-              <exclude>JGitAPIImplTest</exclude>
-              <exclude>LegacyCompatibleGitAPIImplJGitTest</exclude>
-              <exclude>LegacyCompatibleGitAPIImplTest</exclude>
-              <exclude>LogHandlerTest</exclude>
-              <exclude>MergeCommandTest</exclude>
-              <exclude>NetrcTest</exclude>
-              <exclude>PreemptiveAuthHttpClientConnectionTest</exclude>
-              <exclude>PushSimpleTest</exclude>
-              <exclude>PushTest</exclude>
-              <exclude>RemotingTest</exclude>
-              <exclude>RevisionTest</exclude>
-              <exclude>SmartCredentialsProviderTest</exclude>
-              <!-- <exclude>SubmoduleTest</exclude> -->
-              <exclude>TagTest</exclude>
-              <exclude>WarnTempDirValueTest</exclude>
-            </excludes>
-          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1450,15 +1450,15 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
         Path tmpPath = Paths.get(workspaceTmp.getAbsolutePath());
         if (workspaceTmp.getAbsolutePath().contains("%")) {
-            // Avoid ssh expansion of percent in file path
+            // Avoid ssh token expansion
             return createTempFileInSystemDir(prefix, suffix);
         }
         if (isWindows()) {
             /* Windows git fails its call to GIT_SSH if its absolute
-             * path contains a space.  Use system temp dir if path to
-             * workspace tmp dir contains a space.
+             * path contains a space or parentheses.  Use system temp
+             * dir instead of workspace temp dir.
              */
-            if (workspaceTmp.getAbsolutePath().contains(" ")) {
+            if (workspaceTmp.getAbsolutePath().matches(".*[( )].*")) {
                 return createTempFileInSystemDir(prefix, suffix);
             }
             return Files.createTempFile(tmpPath, prefix, suffix).toFile();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1456,7 +1456,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
         Path tmpPath = Paths.get(workspaceTmp.getAbsolutePath());
         if (workspaceTmp.getAbsolutePath().contains("%")) {
-            // Avoid ssh token expansion
+            // Avoid ssh token expansion by ssh implementation
             return createTempFileInSystemDir(prefix, suffix);
         }
         if (isWindows()) {
@@ -1468,6 +1468,11 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                 return createTempFileInSystemDir(prefix, suffix);
             }
             return Files.createTempFile(tmpPath, prefix, suffix).toFile();
+        } else {
+            if (workspaceTmp.getAbsolutePath().contains("`")) {
+                // Avoid shell command expansion in temporary file name
+                return createTempFileInSystemDir(prefix, suffix);
+            }
         }
         Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rw-------");
         FileAttribute fileAttribute = PosixFilePermissions.asFileAttribute(ownerOnly);

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1461,10 +1461,10 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         }
         if (isWindows()) {
             /* Windows git fails its call to GIT_SSH if its absolute
-             * path contains a space or parentheses.  Use system temp
-             * dir instead of workspace temp dir.
+             * path contains a space or parentheses or pipe or question mark.
+             * Use system temp dir instead of workspace temp dir.
              */
-            if (workspaceTmp.getAbsolutePath().matches(".*[( )].*")) {
+            if (workspaceTmp.getAbsolutePath().matches(".*[( )|?].*")) {
                 return createTempFileInSystemDir(prefix, suffix);
             }
             return Files.createTempFile(tmpPath, prefix, suffix).toFile();

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1863,13 +1863,13 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
         // JENKINS-13356: capture the output of stderr separately
         ByteArrayOutputStream err = new ByteArrayOutputStream();
 
-        EnvVars environment = new EnvVars(env);
+        EnvVars freshEnv = new EnvVars(env);
         // If we don't have credentials, but the requested URL requires them,
         // it is possible for Git to hang forever waiting for interactive
         // credential input. Prevent this by setting GIT_ASKPASS to "echo"
         // if we haven't already set it.
         if (!env.containsKey("GIT_ASKPASS")) {
-            environment.put("GIT_ASKPASS", "echo");
+            freshEnv.put("GIT_ASKPASS", "echo");
         }
         String command = gitExe + " " + StringUtils.join(args.toCommandArray(), " ");
         try {
@@ -1881,7 +1881,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
             }
             listener.getLogger().println(" > " + command + (timeout != null ? TIMEOUT_LOG_PREFIX + timeout : ""));
             Launcher.ProcStarter p = launcher.launch().cmds(args.toCommandArray()).
-                    envs(environment).stdout(fos).stderr(err);
+                    envs(freshEnv).stdout(fos).stderr(err);
             if (workDir != null) p.pwd(workDir);
             int status = p.start().joinWithTimeout(timeout != null ? timeout : TIMEOUT, TimeUnit.MINUTES, listener);
 

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -1426,12 +1426,18 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     /**
-     * Create temporary file that is aware of the specific limitations of
-     * command line git.  For example, Windows temporary files may not
-     * contain a space anywhere in their path, otherwise they break the ssh
-     * argument passing.  No temporary file name may include a percent sign
-     * in its path because ssh uses the percent sign character as the start
-     * of token indicator for token expansion.
+     * Create temporary file that is aware of the specific limitations
+     * of command line git.
+     *
+     * For example, no temporary file name (Windows or Unix) may
+     * include a percent sign in its path because ssh uses the percent
+     * sign character as the start of token indicator for token
+     * expansion.
+     *
+     * As another example, windows temporary files may not contain a
+     * space, an open parenthesis, or a close parenthesis anywhere in
+     * their path, otherwise they break ssh argument passing through
+     * the GIT_SSH or SSH_ASKPASS environment variable.
      *
      * @param prefix file name prefix for the generated temporary file
      * @param suffix file name suffix for the generated temporary file

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -119,7 +119,7 @@ public class CredentialsTest {
                 + show("key", privateKey));
     }
 
-    private final String SPECIALS_TO_CHECK = " %"; // " `~!#$%^&*()_+-={}[]|<>,?.";
+    private final String SPECIALS_TO_CHECK = " %( )"; // " `~!#$%^&*()_+-={}[]|<>,?.";
     private static int specialsIndex = 0;
 
     @Before

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -82,7 +82,7 @@ public class CredentialsTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Rule
-    public Timeout timeout = Timeout.seconds(7);
+    public Timeout timeout = Timeout.seconds(13);
 
     private int logCount;
     private LogHandler handler;
@@ -137,9 +137,11 @@ public class CredentialsTest {
             }
             File repoParent = repo;
             repo = new File(repoParent, newDirName);
-            assertTrue(repo.mkdirs());
+            boolean dirCreated = repo.mkdirs();
+            assertTrue("Failed to create " + repo.getAbsolutePath(), dirCreated);
             File repoTemp = new File(repoParent, newDirName + "@tmp"); // use adjacent temp directory
-            assertTrue(repoTemp.mkdirs());
+            dirCreated = repoTemp.mkdirs();
+            assertTrue("Failed to create " + repoTemp.getAbsolutePath(), dirCreated);
         }
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
         handler = new LogHandler();
@@ -333,7 +335,7 @@ public class CredentialsTest {
         Collections.shuffle(repos); // randomize test order
         int toIndex = repos.size() < 3 ? repos.size() : 3;
         if (TEST_ALL_CREDENTIALS) {
-            toIndex = repos.size();
+            toIndex = Math.min(repos.size(), 20); // Don't run more than 20 variations of test - about 3 minutes
         }
         return repos.subList(0, toIndex);
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -119,7 +119,7 @@ public class CredentialsTest {
                 + show("key", privateKey));
     }
 
-    private final String SPECIALS_TO_CHECK = "`~!#$%^&*()_+-={}[]|<>,?.";
+    private final String SPECIALS_TO_CHECK = " %"; // " `~!#$%^&*()_+-={}[]|<>,?.";
     private static int specialsIndex = 0;
 
     @Before
@@ -127,8 +127,9 @@ public class CredentialsTest {
         repo = tempFolder.newFolder();
         if (random.nextBoolean() || true) {
             /* Randomly use a repo with a special character in name - JENKINS-43931 */
-            String newDirName = "a space " + SPECIALS_TO_CHECK.charAt(specialsIndex);
-            if (++specialsIndex >= SPECIALS_TO_CHECK.length()) {
+            String newDirName = "a space" + SPECIALS_TO_CHECK.charAt(specialsIndex);
+            specialsIndex = specialsIndex + 1;
+            if (specialsIndex >= SPECIALS_TO_CHECK.length()) {
                 specialsIndex = 0;
             }
             File repoParent = repo;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -119,15 +119,22 @@ public class CredentialsTest {
                 + show("key", privateKey));
     }
 
+    private final String SPECIALS_TO_CHECK = "`~!#$%^&*()_+-={}[]|<>,?.";
+    private static int specialsIndex = 0;
+
     @Before
     public void setUp() throws IOException, InterruptedException {
         repo = tempFolder.newFolder();
-        if (random.nextBoolean()) {
-            /* Randomly use a repo with a space in name - JENKINS-43931 */
+        if (random.nextBoolean() || true) {
+            /* Randomly use a repo with a special character in name - JENKINS-43931 */
+            String newDirName = "a space " + SPECIALS_TO_CHECK.charAt(specialsIndex);
+            if (++specialsIndex >= SPECIALS_TO_CHECK.length()) {
+                specialsIndex = 0;
+            }
             File repoParent = repo;
-            repo = new File(repoParent, "a space");
+            repo = new File(repoParent, newDirName);
             assertTrue(repo.mkdirs());
-            File repoTemp = new File(repoParent, "a space@tmp"); // allows adjacent temp directory use
+            File repoTemp = new File(repoParent, newDirName + "@tmp"); // allows adjacent temp directory use
             assertTrue(repoTemp.mkdirs());
         }
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -466,5 +466,5 @@ public class CredentialsTest {
      */
     private static final String NOT_JENKINS = System.getProperty("JOB_NAME") == null ? "true" : "false";
     private static final boolean TEST_ALL_CREDENTIALS = Boolean.valueOf(System.getProperty("TEST_ALL_CREDENTIALS", NOT_JENKINS));
-    private static final Pattern URL_MUST_MATCH_PATTERN = Pattern.compile(System.getProperty("URL_MUST_MATCH_PATTERN", ".*hasphrase.*"));
+    private static final Pattern URL_MUST_MATCH_PATTERN = Pattern.compile(System.getProperty("URL_MUST_MATCH_PATTERN", ".*"));
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -82,7 +82,7 @@ public class CredentialsTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Rule
-    public Timeout timeout = Timeout.seconds(17);
+    public Timeout timeout = Timeout.seconds(7);
 
     private int logCount;
     private LogHandler handler;
@@ -120,18 +120,17 @@ public class CredentialsTest {
     }
 
     /* Windows refuses directory names with '*', '<', '>' and ':' */
-    private final String SPECIALS_TO_CHECK = isWindows()
-            ? " %()`~!#$%^&_+-={}[]|?.," // "*<>:" -- Windows exclusions
-            : " %()`~!#$%^&_+-={}[]|?.,*<>:"; // "" -- Linux exclusion
+    private final String SPECIALS_TO_CHECK = " %()`~!#$%^&_+-={}[]|?.,"
+            + (isWindows() ? "" : "*<>:");
     private static int specialsIndex = 0;
 
     @Before
     public void setUp() throws IOException, InterruptedException {
         git = null;
         repo = tempFolder.newFolder();
-        if (random.nextBoolean() || true) {
-            /* Randomly use a repo with a special character in name - JENKINS-43931 */
-            String newDirName = "embedded " + SPECIALS_TO_CHECK.charAt(specialsIndex) + " and space";
+        if (random.nextBoolean()) {
+            /* Use a repo with a special character in name - JENKINS-43931 */
+            String newDirName = "with " + SPECIALS_TO_CHECK.charAt(specialsIndex) + " and space";
             specialsIndex = specialsIndex + 1;
             if (specialsIndex >= SPECIALS_TO_CHECK.length()) {
                 specialsIndex = 0;
@@ -139,7 +138,7 @@ public class CredentialsTest {
             File repoParent = repo;
             repo = new File(repoParent, newDirName);
             assertTrue(repo.mkdirs());
-            File repoTemp = new File(repoParent, newDirName + "@tmp"); // allows adjacent temp directory use
+            File repoTemp = new File(repoParent, newDirName + "@tmp"); // use adjacent temp directory
             assertTrue(repoTemp.mkdirs());
         }
         Logger logger = Logger.getLogger(this.getClass().getPackage().getName() + "-" + logCount++);
@@ -464,7 +463,7 @@ public class CredentialsTest {
     }
 
     private boolean isWindows() {
-        return File.pathSeparatorChar==';';
+        return File.pathSeparatorChar == ';';
     }
 
     /* If not in a Jenkins job, then default to run all credentials tests.

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -119,7 +119,7 @@ public class CredentialsTest {
                 + show("key", privateKey));
     }
 
-    /* Windows refuses directory names with '*', '<', '>' and ':' */
+    /* Windows refuses directory names with '*', '<', '>', '|', '?', and ':' */
     private final String SPECIALS_TO_CHECK = " %()`~!#$%^&_+-={}[].,"
             + (isWindows() ? "" : "*<>:|?");
     private static int specialsIndex = 0;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -82,7 +82,7 @@ public class CredentialsTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Rule
-    public Timeout timeout = Timeout.seconds(7);
+    public Timeout timeout = Timeout.seconds(13);
 
     private int logCount;
     private LogHandler handler;

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -463,7 +463,6 @@ public class CredentialsTest {
         return "";
     }
 
-    /** inline ${@link hudson.Functions#isWindows()} to prevent a transient remote classloader issue */
     private boolean isWindows() {
         return File.pathSeparatorChar==';';
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -335,7 +335,7 @@ public class CredentialsTest {
         Collections.shuffle(repos); // randomize test order
         int toIndex = repos.size() < 3 ? repos.size() : 3;
         if (TEST_ALL_CREDENTIALS) {
-            toIndex = Math.min(repos.size(), 20); // Don't run more than 20 variations of test - about 3 minutes
+            toIndex = Math.min(repos.size(), 60); // Don't run more than 60 variations of test - about 9 minutes
         }
         return repos.subList(0, toIndex);
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -120,8 +120,8 @@ public class CredentialsTest {
     }
 
     /* Windows refuses directory names with '*', '<', '>' and ':' */
-    private final String SPECIALS_TO_CHECK = " %()`~!#$%^&_+-={}[]|?.,"
-            + (isWindows() ? "" : "*<>:");
+    private final String SPECIALS_TO_CHECK = " %()`~!#$%^&_+-={}[].,"
+            + (isWindows() ? "" : "*<>:|?");
     private static int specialsIndex = 0;
 
     @Before

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -458,5 +458,5 @@ public class CredentialsTest {
      */
     private static final String NOT_JENKINS = System.getProperty("JOB_NAME") == null ? "true" : "false";
     private static final boolean TEST_ALL_CREDENTIALS = Boolean.valueOf(System.getProperty("TEST_ALL_CREDENTIALS", NOT_JENKINS));
-    private static final Pattern URL_MUST_MATCH_PATTERN = Pattern.compile(System.getProperty("URL_MUST_MATCH_PATTERN", ".*"));
+    private static final Pattern URL_MUST_MATCH_PATTERN = Pattern.compile(System.getProperty("URL_MUST_MATCH_PATTERN", ".*hasphrase.*"));
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CredentialsTest.java
@@ -82,7 +82,7 @@ public class CredentialsTest {
     public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Rule
-    public Timeout timeout = Timeout.seconds(13);
+    public Timeout timeout = Timeout.seconds(17);
 
     private int logCount;
     private LogHandler handler;


### PR DESCRIPTION
Fix bugs related to special characters in workspace path

* [JENKINS-44041](https://issues.jenkins-ci.org/browse/JENKINS-44041) - Windows authenticated git checkout fails if '(' or ')' in path to workspace
* [JENKINS-43931](https://issues.jenkins-ci.org/browse/JENKINS-43931) - Windows authenticated git checkout fails if ' ' in path to workspace
* [JENKINS-44127](https://issues.jenkins-ci.org/browse/JENKINS-44127) - Authenticated git checkout fails if '%' in path to workspace
